### PR TITLE
Fix graph viewport on hyperlink click

### DIFF
--- a/cs-connect/webapp/src/components/backstage/widgets/graph/graph.tsx
+++ b/cs-connect/webapp/src/components/backstage/widgets/graph/graph.tsx
@@ -75,7 +75,7 @@ type Props = {
 const DESCRIPTION_ID_PREFIX = 'graph-';
 
 // Pixels between each levels in the graph
-const GRAP_RANK_SEP = 75;
+const GRAP_RANK_SEP = 85;
 
 // This is the style for the dashboard
 const defaultGraphStyle: GraphStyle = {
@@ -234,14 +234,14 @@ const Graph = ({
         } else if (!urlHashedNode && targetNode) {
             // The data has changed but there's still a targetNode left over, so we reset it and the viewport position
             // (the latter to avoid ending up with an empty viewport in some corner of the graph)
-            setViewport({x: 0, y: 0, zoom: 0.5});
+            setViewport({x: 0, y: 0, zoom: 0.6});
             setTargetNode(undefined);
         }
     }, [data, getNode]);
 
     useEffect(() => {
         if (targetNode) {
-            fitView({nodes: [targetNode], maxZoom: 0.5});
+            fitView({nodes: [targetNode], maxZoom: 0.6});
         }
     }, [targetNode, fitView]);
 


### PR DESCRIPTION
When the user clicks a hyperlink pointing at a node outside the react flow canvas, the graph would basically break by not being draggable anymore, along with the controls being hidden.

The problem seems to be caused by the `useScrollIntoView` hook, used globally to scroll a particular element of the plugin UI into view. Whenever this scroll happened, the node would scroll into sight not through react flow mechanisms, but by setting the scrollLeft/Top/... properties on the ReactFlow div node. The reactflow library doesn't get notified about this and setting the viewport or fitting the view anyhow wouldn't resolve this since those properties would still keep their values.

~To solve this, in an useEffect depending on the data I simply set the viewport based on the target node position and scroll the div back to the 0,0 origin point. This seems to produce a consistent effect across various tests.~

Examples:
![immagine](https://github.com/CS-AWARE-NEXT/cs-aware-next-cs-connect/assets/11891037/703704e2-5684-4d82-a28c-0d5124ca547a)


I've replaced the manual viewport coordinates calculation with the use of fitView, which now works when paired to the scrollTo fix. In this way the code's simpler to understand and the node is perfectly centered in the viewport.