### PR TITLE
Fix suggestions autocomplete not reloading when navigating to Threads

### DIFF
--- a/cs-connect/webapp/src/hooks/browser.ts
+++ b/cs-connect/webapp/src/hooks/browser.ts
@@ -120,12 +120,8 @@ export const useOnScreen = (ref: RefObject<HTMLDivElement | null>, options?: Int
  */
 export const useDOMReadyById = (id: string): boolean => {
     const [DOMReady, setDOMReady] = useState(false);
-    if (!DOMReady) {
-        setTimeout(() => {
-            if (document.getElementById(id)) {
-                setDOMReady(true);
-            }
-        });
-    }
+    setTimeout(() => {
+        setDOMReady(document.getElementById(id) !== null);
+    });
     return DOMReady;
 };

--- a/cs-connect/webapp/src/hooks/suggestions.ts
+++ b/cs-connect/webapp/src/hooks/suggestions.ts
@@ -54,6 +54,9 @@ const useHandleSuggestionsVisibility = (): [boolean, Dispatch<SetStateAction<boo
         const textarea = (document.getElementById('post_textbox') as HTMLTextAreaElement);
 
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (!textarea) {
+                return;
+            }
             if (event.key === 'Enter') {
                 // event.preventDefault();
                 setIsVisible(false);
@@ -94,6 +97,9 @@ const useHandleSuggestionsVisibility = (): [boolean, Dispatch<SetStateAction<boo
         };
 
         const handleInput = () => {
+            if (!textarea) {
+                return;
+            }
             const [text, cursorStartPosition] = getTextAndCursorPositions(textarea);
             const symbolStartIndex = text.lastIndexOf(getStartSymbol(), cursorStartPosition);
             if (symbolStartIndex === -1) {
@@ -131,6 +137,9 @@ export const useSuggestionsData = (defaultData: SuggestionsData): SuggestionsDat
         const textarea = (document.getElementById('post_textbox') as HTMLTextAreaElement);
 
         const handleInput = async () => {
+            if (!textarea) {
+                return;
+            }
             const tokens = getSuggestionsTokens(textarea);
             if (!tokens) {
                 return;
@@ -145,7 +154,9 @@ export const useSuggestionsData = (defaultData: SuggestionsData): SuggestionsDat
             setData(suggestions);
         };
 
-        textarea.addEventListener('input', handleInput);
+        if (textarea) {
+            textarea.addEventListener('input', handleInput);
+        }
         handleInput();
 
         return () => {


### PR DESCRIPTION
Added some needed null checks which were required on Chrome (but not on Firefox... weird). Also, the DOMReady hook now properly returns false when the requested DOM node isn't available anymore