### PR TITLE
Open accordion when navigating to one of its elements through a hyperlink from another channel

### DIFF
--- a/cs-connect/webapp/src/components/backstage/widgets/accordion/accordion.tsx
+++ b/cs-connect/webapp/src/components/backstage/widgets/accordion/accordion.tsx
@@ -106,7 +106,7 @@ const Accordion = ({
                 // }
             }
         }
-    }, [urlHash]);
+    }, [urlHash, elements]);
 
     const id = `${formatName(name)}-${sectionId}-${parentId}-widget`;
 

--- a/cs-connect/webapp/src/components/backstage/widgets/paginated_table/paginated_table.tsx
+++ b/cs-connect/webapp/src/components/backstage/widgets/paginated_table/paginated_table.tsx
@@ -81,7 +81,6 @@ export const fillColumn = (title: string, sortable: boolean | undefined): Pagina
         sorter: (a: PaginatedTableRow, b: PaginatedTableRow) => {
             const aValue = a[formattedTitle];
             const bValue = b[formattedTitle];
-            console.log('a', {a}, 'b', {b}, 'aValue', {aValue}, 'bValue', {bValue});
             if (!isNaN(Number(aValue)) && !isNaN(Number(bValue))) {
                 return Number(aValue) - Number(bValue);
             }


### PR DESCRIPTION
During initial rendering, the elements array was empty. Instead of not rendering the accordion in this case (to avoid it appearing after a delay), I believe the best solution is to add elements as an useEffect dependency.

I also cleaned a console.log introduced by some previous commit.