### PR TITLE
Parse urls for all list widget items

### DIFF
--- a/cs-connect/webapp/src/components/backstage/widgets/exercise/exercise_parts/assignment_part.tsx
+++ b/cs-connect/webapp/src/components/backstage/widgets/exercise/exercise_parts/assignment_part.tsx
@@ -8,7 +8,6 @@ import {buildQuery} from 'src/hooks';
 import {formatName} from 'src/helpers';
 import {AccordionData} from 'src/types/accordion';
 import ItemsList from 'src/components/backstage/widgets/list/list';
-import FormattedMarkdown from 'src/components/commons/formatted_markdown';
 
 type Props = {
     data: AccordionData;
@@ -43,7 +42,7 @@ const AssignmentPart = ({
     })) ?? [];
     const educationItems = data?.educationMaterial?.map((part: string, index: number) => ({
         id: `education-${index}`,
-        text: <FormattedMarkdown value={part}/>,
+        text: part,
     })) ?? [];
 
     return (

--- a/cs-connect/webapp/src/components/backstage/widgets/list/list.tsx
+++ b/cs-connect/webapp/src/components/backstage/widgets/list/list.tsx
@@ -16,6 +16,7 @@ import {
 import {formatName} from 'src/helpers';
 import {ListData} from 'src/types/list';
 import {CopyLinkMenuItem} from 'src/components/commons/copy_link';
+import FormattedMarkdown from 'src/components/commons/formatted_markdown';
 
 const {Item} = List;
 const {Meta} = Item;
@@ -90,9 +91,9 @@ const ItemsList = ({
                             {Avatar ?
                                 <Meta
                                     avatar={Avatar}
-                                    title={item.text}
+                                    title={<FormattedMarkdown value={item.text}/>}
                                 /> :
-                                <Meta title={item.text}/>}
+                                <Meta title={<FormattedMarkdown value={item.text}/>}/>}
                         </Item>
                     );
                 }}


### PR DESCRIPTION
URLs within list items are now parsed as such. Other than list widgets, this also includes lists in playbooks, exercises (which already had an ad-hoc implementation now removed) and ecosystem attachments.