### PR TITLE
Fix setting ALL org for new users, search functionality in the org set select

### DIFF
--- a/cs-connect/webapp/src/components/lhs/lhs.tsx
+++ b/cs-connect/webapp/src/components/lhs/lhs.tsx
@@ -109,9 +109,12 @@ const LHSView = () => {
         setIsPasswordInvalid(false);
     };
 
-    if (userProps && userProps.orgId !== '' && selectedObject !== defaultSelectObject) {
+    if (userProps && userProps.orgId && selectedObject !== defaultSelectObject) {
         return <StyledContainer>{selectedObject.label}</StyledContainer>;
     }
+
+    const filterOption = (input: string, option?: any) =>
+        (option?.label ?? '').toLowerCase().includes(input.toLowerCase());
 
     return (
         <>
@@ -177,9 +180,10 @@ const LHSView = () => {
                 style={{width: '100%'}}
                 placeholder={formatMessage({defaultMessage: 'Search or select'})}
                 optionFilterProp='children'
+                filterOption={filterOption}
 
                 options={options}
-                onChange={(value: any) => setSelectedObject({value, label: value})}
+                onChange={(value: any, option: any) => setSelectedObject({value, label: option.label})}
             />
         </>
     );


### PR DESCRIPTION
https://trello.com/c/KUVlS8Rp/130-selecting-all-in-organizations-when-you-register-a-new-users-fails

Due to an incorrect check( !== '' vs falsy value which checks undefined too, since userProps can be an empty js object), users with no props (such as newly registered ones) would skip the server side save of the set organization. 
I've also restored the search functionality (I wrongly assumed antd did it automatically by default, my bad)