### PR TITLE
Backlinks lazy regex to handle multiple backlinks in a single message

### DIFF
--- a/cs-connect/server/app/channel_service.go
+++ b/cs-connect/server/app/channel_service.go
@@ -32,7 +32,7 @@ func NewChannelService(api plugin.API, store ChannelStore, mattermostChannelStor
 		mattermostChannelStore: mattermostChannelStore,
 		categoryService:        categoryService,
 		platformService:        platformService,
-		markdownRegex:          regexp.MustCompile(`\[(.*)\]\(([^\(]+)\)`),
+		markdownRegex:          regexp.MustCompile(`\[(.*?)\]\(([^\(]+)\)`),
 	}
 }
 


### PR DESCRIPTION
Can be validated here: https://regexr.com/
Regex: `\[(.*?)\]\(([^\(]+)\)`
Example of text: `1 [Demo CS-AWARE EU.Bundles.Malicious Site Hosting Downloader.x4z9arb backdoor.Description](http://localhost:8065/cs/channels/demo-cs-aware-eu-malicious-site-hosting-downloader?parentId=35&sectionId=e95ef29c-1ee8-45e5-a14b-019846e4dece#malware-description-e95ef29c-1ee8-45e5-a14b-019846e4dece-35-widget), 2 [Demo CS-AWARE EU.Bundles.Malicious Site Hosting Downloader.x4z9arb backdoor.Kill Chain Phases.mandiant-attack-lifecycle-model](http://localhost:8065/cs/channels/demo-cs-aware-eu-malicious-site-hosting-downloader?parentId=35&sectionId=e95ef29c-1ee8-45e5-a14b-019846e4dece#table-row-mandiant-attack-lifecycle-model)`